### PR TITLE
Replace misplaced pipe

### DIFF
--- a/vignettes/eco-analysis.Rmd
+++ b/vignettes/eco-analysis.Rmd
@@ -220,7 +220,7 @@ nice_diversity_tidy %>%
   theme_bw() + 
   theme(strip.background = element_blank(),
         strip.text = element_text(size = 12),
-        legend.position = "top") %>%
+        legend.position = "top") +
   labs(col = "Classification: ",
        title = "Alpha diversity across water mass")
 ```


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
We traced it to a misuse of `labs()` that was at the end of a pipe instead of a `+` chain.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time or let us know when ggplot2 should change. Hopefully this will inform you in a timely manner.

Best wishes,
Teun
